### PR TITLE
make all client socket ignoring sigpipe

### DIFF
--- a/src/http/connectionHandler.cpp
+++ b/src/http/connectionHandler.cpp
@@ -30,4 +30,10 @@ void HTTP::acceptConnection(const int serverFd, std::vector<Client*>& clients) {
         std::cerr << "webserv: fcntl(): " << strerror(errno) << std::endl;
         throw 500;
     }
+
+    int opt = 1;
+    if (setsockopt(clientFd, SOL_SOCKET, SO_NOSIGPIPE, &opt, sizeof(opt)) == -1) {
+        std::cerr << "webserv: setsockopt(): " << strerror(errno) << std::endl;
+        throw 500;
+    }
 }


### PR DESCRIPTION
this happens in rare cases, writing to client socket  that disconnected in that moment.